### PR TITLE
feat: migrate save_static_file to ProjectFileParameter

### DIFF
--- a/runwayml/act_two.py
+++ b/runwayml/act_two.py
@@ -4,8 +4,8 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import prepare_media_data_uri
@@ -203,6 +203,9 @@ class RunwayML_ActTwo(ControlNode):
             )
         )
 
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="output.mp4")
+        self._output_file.add_parameter()
+
         # Initialize parameter visibility based on default character type
         self._update_parameter_visibility(DEFAULT_CHARACTER_TYPE)
 
@@ -337,29 +340,11 @@ class RunwayML_ActTwo(ControlNode):
                 logger.info(f"RunwayML Act Two: Downloading video from {video_url}")
                 file_content = File(video_url).read()
 
-                content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-                if "quicktime" in content_type or content_type.endswith("/mov"):
-                    extension = "mov"
-                elif "webm" in content_type:
-                    extension = "webm"
-                elif "ogg" in content_type:
-                    extension = "ogv"
-                elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                    extension = "mp4"
-                else:
-                    extension = "mp4"
-
-                if task_id:
-                    filename = f"runwayml_act_two_{task_id}.{extension}"
-                else:
-                    filename = f"runwayml_act_two_{int(time.time() * 1000)}.{extension}"
-
-                logger.info(f"RunwayML Act Two: Saving video bytes to static storage as {filename}...")
-                static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                    file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-                )
-                logger.info(f"RunwayML Act Two: ✅ Video saved. URL: {static_url}")
-                return VideoUrlArtifact(url=static_url, name="runwayml_character_video")
+                logger.info("RunwayML Act Two: Saving video bytes to project storage...")
+                dest = self._output_file.build_file()
+                dest.write_bytes(file_content.content)
+                logger.info(f"RunwayML Act Two: Video saved. URL: {dest.location}")
+                return VideoUrlArtifact(url=dest.location, name="runwayml_character_video")
             except FileLoadError as e:
                 logger.error(f"RunwayML Act Two: Failed to download and store video: {e}")
                 return VideoUrlArtifact(url=video_url, name="runwayml_character_video")

--- a/runwayml/image_to_video.py
+++ b/runwayml/image_to_video.py
@@ -5,8 +5,8 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import prepare_media_data_uri
@@ -137,6 +137,9 @@ class RunwayML_ImageToVideo(ControlNode):
             )
         )
 
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="output.mp4")
+        self._output_file.add_parameter()
+
     def _get_image_data_uri(self, param_name: str) -> str | None:
         """Resolve an image input to a value the /v1/image_to_video endpoint accepts."""
         return prepare_media_data_uri(
@@ -187,29 +190,11 @@ class RunwayML_ImageToVideo(ControlNode):
             logger.info(f"RunwayML I2V: Downloading video from {video_url}")
             file_content = File(video_url).read()
 
-            content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-            if "quicktime" in content_type or content_type.endswith("/mov"):
-                extension = "mov"
-            elif "webm" in content_type:
-                extension = "webm"
-            elif "ogg" in content_type:
-                extension = "ogv"
-            elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                extension = "mp4"
-            else:
-                extension = "mp4"
-
-            if task_id:
-                filename = f"runwayml_image_to_video_{task_id}.{extension}"
-            else:
-                filename = f"runwayml_image_to_video_{int(time.time() * 1000)}.{extension}"
-
-            logger.info(f"RunwayML I2V: Saving video bytes to static storage as {filename}...")
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-            )
-            logger.info(f"RunwayML I2V: ✅ Video saved. URL: {static_url}")
-            return VideoUrlArtifact(url=static_url, name="runwayml_video")
+            logger.info("RunwayML I2V: Saving video bytes to project storage...")
+            dest = self._output_file.build_file()
+            dest.write_bytes(file_content.content)
+            logger.info(f"RunwayML I2V: Video saved. URL: {dest.location}")
+            return VideoUrlArtifact(url=dest.location, name="runwayml_video")
         except FileLoadError as e:
             logger.error(f"RunwayML I2V: Failed to download and store video: {e}")
             return VideoUrlArtifact(url=video_url, name="runwayml_video")

--- a/runwayml/text_to_image.py
+++ b/runwayml/text_to_image.py
@@ -6,8 +6,8 @@ import requests
 from griptape.artifacts import BaseArtifact, ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterList, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import prepare_media_data_uri
@@ -220,6 +220,9 @@ class RunwayML_TextToImage(ControlNode):
             )
         )
 
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="output.png")
+        self._output_file.add_parameter()
+
     def _get_image_data_uri(self, image_input) -> str | None:
         """Convert various image input types to a data URI or HTTPS URL accepted by RunwayML.
 
@@ -289,35 +292,15 @@ class RunwayML_TextToImage(ControlNode):
         return validated
 
     def _download_and_store_image(self, image_url: str, task_id: str = None) -> ImageUrlArtifact:
-        """Download image from URL and store via StaticFilesManager."""
+        """Download image from URL and store via ProjectFileParameter."""
         try:
             logger.info(f"RunwayML T2I: Downloading image from {image_url}")
             file_content = File(image_url).read()
 
-            # Determine file extension from content type
-            content_type = file_content.mime_type if file_content.mime_type else "image/png"
-            if "jpeg" in content_type or "jpg" in content_type:
-                extension = "jpg"
-            elif "png" in content_type:
-                extension = "png"
-            elif "webp" in content_type:
-                extension = "webp"
-            else:
-                extension = "jpg"  # Default fallback
+            dest = self._output_file.build_file()
+            dest.write_bytes(file_content.content)
 
-            # Generate filename using task ID if provided, otherwise use timestamp
-            if task_id:
-                filename = f"runwayml_generated_image_{task_id}.{extension}"
-            else:
-                timestamp = int(time.time() * 1000)  # milliseconds for uniqueness
-                filename = f"runwayml_generated_image_{timestamp}.{extension}"
-
-            # Save via StaticFilesManager
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-            )
-
-            return ImageUrlArtifact(value=static_url, name="runwayml_generated_image")
+            return ImageUrlArtifact(value=dest.location, name="runwayml_generated_image")
 
         except FileLoadError as e:
             logger.error(f"RunwayML T2I: Failed to download and store image: {e}")

--- a/runwayml/video_to_video.py
+++ b/runwayml/video_to_video.py
@@ -8,8 +8,8 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import coerce_media_url_or_data_uri, prepare_media_data_uri
@@ -168,6 +168,9 @@ class RunwayML_VideoToVideo(ControlNode):
                 ui_options={"placeholder_text": ""},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="output.mp4")
+        self._output_file.add_parameter()
 
     def _transcode_video_file(self, video_file_path: str) -> str | None:
         """
@@ -378,29 +381,11 @@ class RunwayML_VideoToVideo(ControlNode):
                 logger.info(f"RunwayML V2V: Downloading video from {video_url}")
                 file_content = File(video_url).read()
 
-                content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-                if "quicktime" in content_type or content_type.endswith("/mov"):
-                    extension = "mov"
-                elif "webm" in content_type:
-                    extension = "webm"
-                elif "ogg" in content_type:
-                    extension = "ogv"
-                elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                    extension = "mp4"
-                else:
-                    extension = "mp4"
-
-                if task_id:
-                    filename = f"runwayml_video_to_video_{task_id}.{extension}"
-                else:
-                    filename = f"runwayml_video_to_video_{int(time.time() * 1000)}.{extension}"
-
-                logger.info(f"RunwayML V2V: Saving video bytes to static storage as {filename}...")
-                static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                    file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-                )
-                logger.info(f"RunwayML V2V: ✅ Video saved. URL: {static_url}")
-                return VideoUrlArtifact(url=static_url, name="runwayml_video_to_video")
+                logger.info("RunwayML V2V: Saving video bytes to project storage...")
+                dest = self._output_file.build_file()
+                dest.write_bytes(file_content.content)
+                logger.info(f"RunwayML V2V: Video saved. URL: {dest.location}")
+                return VideoUrlArtifact(url=dest.location, name="runwayml_video_to_video")
             except FileLoadError as e:
                 logger.error(f"RunwayML V2V: Failed to download and store video: {e}")
                 return VideoUrlArtifact(url=video_url, name="runwayml_video_to_video")

--- a/runwayml/video_upscale.py
+++ b/runwayml/video_upscale.py
@@ -5,8 +5,8 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import prepare_media_data_uri
@@ -95,6 +95,9 @@ class RunwayML_VideoUpscale(ControlNode):
             )
         )
 
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="output.mp4")
+        self._output_file.add_parameter()
+
     # --- Helpers ---
     def _get_video_uri(self) -> str | None:
         """Resolve the ``video`` input to a value the /v1/video_upscale endpoint accepts.
@@ -114,28 +117,9 @@ class RunwayML_VideoUpscale(ControlNode):
             logger.info(f"RunwayML VideoUpscale: Downloading video from {video_url}")
             file_content = File(video_url).read()
 
-            content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-            # Basic mapping for common content-types
-            if "quicktime" in content_type or content_type.endswith("/mov"):
-                extension = "mov"
-            elif "webm" in content_type:
-                extension = "webm"
-            elif "ogg" in content_type:
-                extension = "ogv"
-            elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                extension = "mp4"
-            else:
-                extension = "mp4"
-
-            if task_id:
-                filename = f"runwayml_upscaled_video_{task_id}.{extension}"
-            else:
-                filename = f"runwayml_upscaled_video_{int(time.time() * 1000)}.{extension}"
-
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-            )
-            return VideoUrlArtifact(url=static_url, name="runwayml_upscaled_video")
+            dest = self._output_file.build_file()
+            dest.write_bytes(file_content.content)
+            return VideoUrlArtifact(url=dest.location, name="runwayml_upscaled_video")
         except FileLoadError as e:
             logger.error(f"RunwayML VideoUpscale: Failed to download and store video: {e}")
             # Fallback to original URL if we can't save


### PR DESCRIPTION
Closes #23

Replace `StaticFilesManager.save_static_file()` with `ProjectFileParameter` for project-aware file saving.