### PR TITLE
feat(media): upload media inputs via PublicArtifactUrlParameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .env
 .venv
-example_nodes_template/__pycache__/
-/runwayml/__pycache__
+__pycache__/

--- a/runwayml/act_two.py
+++ b/runwayml/act_two.py
@@ -4,11 +4,15 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
-from media import prepare_media_data_uri
 
 SERVICE = "RunwayML"
 API_KEY_ENV_VAR = "RUNWAYML_API_SECRET"
@@ -62,45 +66,41 @@ class RunwayML_ActTwo(ControlNode):
         self.add_node_element(character_type_group)
 
         # Media Inputs
-
-        self.add_parameter(
-            Parameter(
+        # Each input wraps with PublicArtifactUrlParameter so RunwayML receives a public
+        # HTTPS URL it can fetch directly. This avoids the ~5MB data-URI body cap and lets
+        # the API stream large uploads from Griptape Cloud storage.
+        self._public_character_video = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterVideo(
                 name="character_video",
-                input_types=["VideoUrlArtifact", "VideoArtifact"],
-                type="VideoUrlArtifact",
-                tooltip="The video to process",
-                ui_options={
-                    "clickable_file_browser": True,
-                    "expander": True,
-                    "display_name": "Video or Path to Video",
-                },
-            )
+                tooltip="The character video to drive (used when character type is 'video').",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ),
+            disclaimer_message="RunwayML uses this URL to fetch the character video for generation.",
         )
+        self._public_character_video.add_input_parameters()
 
-        self.add_parameter(
-            Parameter(
+        self._public_reference_video = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterVideo(
                 name="reference_video",
-                input_types=["VideoUrlArtifact", "VideoArtifact"],
-                type="VideoUrlArtifact",
-                tooltip="The video to process",
-                ui_options={
-                    "clickable_file_browser": True,
-                    "expander": True,
-                    "display_name": "Video or Path to Video",
-                },
-            )
+                tooltip="The reference performance video.",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ),
+            disclaimer_message="RunwayML uses this URL to fetch the reference performance video.",
         )
+        self._public_reference_video.add_input_parameters()
 
-        self.add_parameter(
-            Parameter(
+        self._public_character_image = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterImage(
                 name="character_image",
-                input_types=["ImageArtifact", "ImageUrlArtifact", "str"],
-                type="ImageUrlArtifact",
-                tooltip="Input image of the character. Accepts ImageUrlArtifact, a public URL string, or a base64 data URI string.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT},
-                ui_options={"clickable_file_browser": True},
-            )
+                tooltip="Input image of the character (used when character type is 'image').",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ),
+            disclaimer_message="RunwayML uses this URL to fetch the character image.",
         )
+        self._public_character_image.add_input_parameters()
 
         # Settings Group
         with ParameterGroup(name="Settings") as settings_group:
@@ -222,17 +222,29 @@ class RunwayML_ActTwo(ControlNode):
         return super().after_value_set(parameter, value)
 
     def _get_data_uri(self, param_name: str) -> str | None:
-        """Resolve an input parameter to a value the character_performance endpoint accepts.
+        """Resolve a media input parameter to a public URL via Griptape Cloud upload.
 
-        Returns an ``https://``, ``runway://``, or ``data:<kind>/...`` URI, or ``None``
-        when the parameter is unset or could not be loaded.
+        Triggers an upload to Griptape Cloud for non-public inputs (local paths, macro
+        paths, ``data:`` URIs); the upload is reused on subsequent calls within the same
+        node run because the wrapper caches its ``gtc_file_path``.
+
+        Returns ``None`` when the parameter is unset.
         """
-        kind = "image" if param_name == "character_image" else "video"
-        return prepare_media_data_uri(
-            self.get_parameter_value(param_name),
-            kind=kind,
-            node_name="RunwayML Act Two",
-        )
+        wrappers = {
+            "character_image": self._public_character_image,
+            "character_video": self._public_character_video,
+            "reference_video": self._public_reference_video,
+        }
+        wrapper = wrappers.get(param_name)
+        if wrapper is None:
+            return None
+        if not self.get_parameter_value(param_name):
+            return None
+        return wrapper.get_public_url_for_parameter()
+
+    def _has_input(self, param_name: str) -> bool:
+        """Whether ``param_name`` has been set to a truthy value (no upload triggered)."""
+        return bool(self.get_parameter_value(param_name))
 
     def validate_node(self) -> list[Exception] | None:
         errors = []
@@ -249,16 +261,16 @@ class RunwayML_ActTwo(ControlNode):
         character_type = self.get_parameter_value("character_type") or DEFAULT_CHARACTER_TYPE
 
         if character_type == "image":
-            if not self._get_data_uri("character_image"):
+            if not self._has_input("character_image"):
                 errors.append(ValueError("Character image is required when character type is 'image'."))
         elif character_type == "video":
-            if not self._get_data_uri("character_video"):
+            if not self._has_input("character_video"):
                 errors.append(ValueError("Character video is required when character type is 'video'."))
         else:
             errors.append(ValueError(f"Invalid character type: {character_type}. Must be 'image' or 'video'."))
 
         # Validate reference video
-        if not self._get_data_uri("reference_video"):
+        if not self._has_input("reference_video"):
             errors.append(ValueError("Reference video ('reference_video') is required."))
 
         # Validate aspect ratio
@@ -290,16 +302,6 @@ class RunwayML_ActTwo(ControlNode):
 
         # Get parameter values
         character_type = self.get_parameter_value("character_type") or DEFAULT_CHARACTER_TYPE
-
-        # Get the appropriate character input based on type
-        if character_type == "image":
-            character_image_uri = self._get_data_uri("character_image")
-            character_video_uri = None
-        else:
-            character_video_uri = self._get_data_uri("character_video")
-            character_image_uri = None
-
-        reference_video_uri = self._get_data_uri("reference_video")
         ratio_val = str(self.get_parameter_value("ratio") or DEFAULT_ASPECT_RATIO)
 
         # Handle seed control (ComfyUI-style)
@@ -368,9 +370,17 @@ class RunwayML_ActTwo(ControlNode):
             try:
                 api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
 
+                # Resolve media inputs to public URLs RunwayML can fetch directly. Each
+                # call uploads to Griptape Cloud if the input isn't already a public URL.
+                if character_type == "image":
+                    character_uri = self._public_character_image.get_public_url_for_parameter()
+                else:
+                    character_uri = self._public_character_video.get_public_url_for_parameter()
+                reference_video_uri = self._public_reference_video.get_public_url_for_parameter()
+
                 # Build the payload according to the API format
                 task_payload = {
-                    "character": {"type": character_type, "uri": character_image_uri or character_video_uri},
+                    "character": {"type": character_type, "uri": character_uri},
                     "reference": {"type": "video", "uri": reference_video_uri},
                     "bodyControl": body_control,
                     "expressionIntensity": expression_intensity,
@@ -506,5 +516,10 @@ class RunwayML_ActTwo(ControlNode):
                     "seed", actual_seed if "actual_seed" in locals() else RunwayML_ActTwo._last_used_seed
                 )
                 return ErrorArtifact(error_message)
+            finally:
+                # Clean up any artifacts uploaded to Griptape Cloud during this run.
+                self._public_character_image.delete_uploaded_artifact()
+                self._public_character_video.delete_uploaded_artifact()
+                self._public_reference_video.delete_uploaded_artifact()
 
         yield generate_character_performance_async

--- a/runwayml/act_two.py
+++ b/runwayml/act_two.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 import requests
@@ -480,11 +481,17 @@ class RunwayML_ActTwo(ControlNode):
                             return ErrorArtifact(err_msg)
 
                     elif status == "FAILED":
+                        failure_reason = (
+                            task_status.get("error") or task_status.get("failure") or task_status.get("failureCode")
+                        )
                         error_msg = f"RunwayML Act Two generation failed (Task ID: {task_id})."
-                        error_detail = task_status.get("error")
-                        if error_detail:
-                            error_msg += f" Reason: {error_detail}"
-                        logger.error(error_msg)
+                        if failure_reason:
+                            error_msg += f" Reason: {failure_reason}"
+                        logger.error(
+                            "%s Full task status: %s",
+                            error_msg,
+                            json.dumps(task_status, default=str),
+                        )
                         self.publish_update_to_parameter("video_output", ErrorArtifact(error_msg))
                         self.publish_update_to_parameter("seed", actual_seed)
                         return ErrorArtifact(error_msg)

--- a/runwayml/act_two.py
+++ b/runwayml/act_two.py
@@ -8,10 +8,10 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
     PublicArtifactUrlParameter,
 )
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 
@@ -204,6 +204,16 @@ class RunwayML_ActTwo(ControlNode):
             )
         )
 
+        # Save the generated video into the active project workspace via the standard
+        # ProjectFileParameter so the file lives next to the user's other artifacts
+        # rather than inside the engine's ephemeral static-files directory.
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runwayml_act_two.mp4",
+        )
+        self._output_file.add_parameter()
+
         # Initialize parameter visibility based on default character type
         self._update_parameter_visibility(DEFAULT_CHARACTER_TYPE)
 
@@ -340,29 +350,11 @@ class RunwayML_ActTwo(ControlNode):
                 logger.info(f"RunwayML Act Two: Downloading video from {video_url}")
                 file_content = File(video_url).read()
 
-                content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-                if "quicktime" in content_type or content_type.endswith("/mov"):
-                    extension = "mov"
-                elif "webm" in content_type:
-                    extension = "webm"
-                elif "ogg" in content_type:
-                    extension = "ogv"
-                elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                    extension = "mp4"
-                else:
-                    extension = "mp4"
-
-                if task_id:
-                    filename = f"runwayml_act_two_{task_id}.{extension}"
-                else:
-                    filename = f"runwayml_act_two_{int(time.time() * 1000)}.{extension}"
-
-                logger.info(f"RunwayML Act Two: Saving video bytes to static storage as {filename}...")
-                static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                    file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-                )
-                logger.info(f"RunwayML Act Two: ✅ Video saved. URL: {static_url}")
-                return VideoUrlArtifact(url=static_url, name="runwayml_character_video")
+                logger.info("RunwayML Act Two: Writing video bytes to project workspace...")
+                dest = self._output_file.build_file()
+                saved = dest.write_bytes(file_content.content)
+                logger.info(f"RunwayML Act Two: ✅ Video saved as {saved.name} at {saved.location}")
+                return VideoUrlArtifact(url=saved.location, name=saved.name)
             except FileLoadError as e:
                 logger.error(f"RunwayML Act Two: Failed to download and store video: {e}")
                 return VideoUrlArtifact(url=video_url, name="runwayml_character_video")

--- a/runwayml/image_to_video.py
+++ b/runwayml/image_to_video.py
@@ -1,3 +1,4 @@
+import json
 import time
 from typing import Any
 
@@ -330,10 +331,17 @@ class RunwayML_ImageToVideo(ControlNode):
                             return ErrorArtifact(err_msg)
 
                     elif status == "FAILED":
+                        failure_reason = (
+                            task_status.get("error") or task_status.get("failure") or task_status.get("failureCode")
+                        )
                         error_msg = f"RunwayML I2V generation failed (Task ID: {task_id})."
-                        if task_status.error:
-                            error_msg += f" Reason: {task_status.error}"
-                        logger.error(error_msg)
+                        if failure_reason:
+                            error_msg += f" Reason: {failure_reason}"
+                        logger.error(
+                            "%s Full task status: %s",
+                            error_msg,
+                            json.dumps(task_status, default=str),
+                        )
                         self.publish_update_to_parameter("video_output", ErrorArtifact(error_msg))
                         return ErrorArtifact(error_msg)
 

--- a/runwayml/image_to_video.py
+++ b/runwayml/image_to_video.py
@@ -9,9 +9,9 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
     PublicArtifactUrlParameter,
 )
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 
@@ -143,6 +143,16 @@ class RunwayML_ImageToVideo(ControlNode):
             )
         )
 
+        # Save the generated video into the active project workspace via the standard
+        # ProjectFileParameter so the file lives next to the user's other artifacts
+        # rather than inside the engine's ephemeral static-files directory.
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runwayml_image_to_video.mp4",
+        )
+        self._output_file.add_parameter()
+
     def _get_image_data_uri(self, param_name: str) -> str | None:
         """Resolve the ``image`` input to a public HTTPS URL via Griptape Cloud upload.
 
@@ -197,29 +207,11 @@ class RunwayML_ImageToVideo(ControlNode):
             logger.info(f"RunwayML I2V: Downloading video from {video_url}")
             file_content = File(video_url).read()
 
-            content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-            if "quicktime" in content_type or content_type.endswith("/mov"):
-                extension = "mov"
-            elif "webm" in content_type:
-                extension = "webm"
-            elif "ogg" in content_type:
-                extension = "ogv"
-            elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                extension = "mp4"
-            else:
-                extension = "mp4"
-
-            if task_id:
-                filename = f"runwayml_image_to_video_{task_id}.{extension}"
-            else:
-                filename = f"runwayml_image_to_video_{int(time.time() * 1000)}.{extension}"
-
-            logger.info(f"RunwayML I2V: Saving video bytes to static storage as {filename}...")
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-            )
-            logger.info(f"RunwayML I2V: ✅ Video saved. URL: {static_url}")
-            return VideoUrlArtifact(url=static_url, name="runwayml_video")
+            logger.info("RunwayML I2V: Writing video bytes to project workspace...")
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(file_content.content)
+            logger.info(f"RunwayML I2V: ✅ Video saved as {saved.name} at {saved.location}")
+            return VideoUrlArtifact(url=saved.location, name=saved.name)
         except FileLoadError as e:
             logger.error(f"RunwayML I2V: Failed to download and store video: {e}")
             return VideoUrlArtifact(url=video_url, name="runwayml_video")

--- a/runwayml/image_to_video.py
+++ b/runwayml/image_to_video.py
@@ -5,11 +5,14 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
-from media import prepare_media_data_uri
 
 SERVICE = "RunwayML"
 API_KEY_ENV_VAR = "RUNWAYML_API_SECRET"
@@ -39,16 +42,18 @@ class RunwayML_ImageToVideo(ControlNode):
         self.metadata["author"] = "Griptape"
         self.metadata["dependencies"] = {"pip_dependencies": ["requests"]}
 
-        # Individual parameters (following Kling pattern)
-        self.add_parameter(
-            Parameter(
+        # Image input. Wrapped with PublicArtifactUrlParameter so RunwayML receives a
+        # public HTTPS URL it can fetch directly, sidestepping the data-URI body cap.
+        self._public_image = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterImage(
                 name="image",
-                input_types=["ImageUrlArtifact", "str"],
-                type="ImageUrlArtifact",
-                tooltip="Input image (required). Accepts ImageUrlArtifact, a public URL string, or a base64 data URI string.",
-                allowed_modes={ParameterMode.INPUT},
-            )
+                tooltip="Input image (required).",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ),
+            disclaimer_message="RunwayML uses this URL to fetch the image for video generation.",
         )
+        self._public_image.add_input_parameters()
         self.add_parameter(
             Parameter(
                 name="prompt",
@@ -138,12 +143,16 @@ class RunwayML_ImageToVideo(ControlNode):
         )
 
     def _get_image_data_uri(self, param_name: str) -> str | None:
-        """Resolve an image input to a value the /v1/image_to_video endpoint accepts."""
-        return prepare_media_data_uri(
-            self.get_parameter_value(param_name),
-            kind="image",
-            node_name="RunwayML I2V",
-        )
+        """Resolve the ``image`` input to a public HTTPS URL via Griptape Cloud upload.
+
+        Public URLs pass through unchanged; macro paths and local files are uploaded.
+        Returns ``None`` when the parameter is unset.
+        """
+        if param_name != "image":
+            return None
+        if not self.get_parameter_value(param_name):
+            return None
+        return self._public_image.get_public_url_for_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         errors = []
@@ -156,7 +165,7 @@ class RunwayML_ImageToVideo(ControlNode):
                 )
             )
 
-        image_data = self._get_image_data_uri("image")
+        image_data = self.get_parameter_value("image")
         if not image_data:
             errors.append(
                 ValueError(
@@ -229,16 +238,12 @@ class RunwayML_ImageToVideo(ControlNode):
         seed_val = self.get_parameter_value("seed") or 0
         duration_val = self.get_parameter_value("duration") or 10
 
-        # Get image data
-        image_data_uri = self._get_image_data_uri("image")
-        if not image_data_uri:
-            error_msg = "Failed to process image input."
-            self.publish_update_to_parameter("video_output", ErrorArtifact(error_msg))
-            raise ValueError(error_msg)
-
         def generate_video_async() -> VideoUrlArtifact | ErrorArtifact:
             try:
                 api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+
+                # Resolve to a public HTTPS URL (uploads to Griptape Cloud if needed).
+                image_data_uri = self._public_image.get_public_url_for_parameter()
 
                 task_payload = {
                     "model": model_name,
@@ -345,5 +350,8 @@ class RunwayML_ImageToVideo(ControlNode):
                 logger.exception(error_message)
                 self.publish_update_to_parameter("video_output", ErrorArtifact(error_message))
                 return ErrorArtifact(error_message)
+            finally:
+                # Clean up any artifact uploaded to Griptape Cloud during this run.
+                self._public_image.delete_uploaded_artifact()
 
         yield generate_video_async

--- a/runwayml/text_to_image.py
+++ b/runwayml/text_to_image.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 import time
 
 import requests
@@ -673,11 +674,17 @@ class RunwayML_TextToImage(ControlNode):
                             return ErrorArtifact(err_msg)
 
                     elif status == "FAILED":
+                        failure_reason = (
+                            task_status.get("error") or task_status.get("failure") or task_status.get("failureCode")
+                        )
                         error_msg = f"RunwayML T2I generation failed (Task ID: {task_id})."
-                        error_detail = task_status.get("error")
-                        if error_detail:
-                            error_msg += f" Reason: {error_detail}"
-                        logger.error(error_msg)
+                        if failure_reason:
+                            error_msg += f" Reason: {failure_reason}"
+                        logger.error(
+                            "%s Full task status: %s",
+                            error_msg,
+                            json.dumps(task_status, default=str),
+                        )
                         self.publish_update_to_parameter("image_output", ErrorArtifact(error_msg))
                         self.publish_update_to_parameter("seed", actual_seed)
                         return ErrorArtifact(error_msg)

--- a/runwayml/text_to_image.py
+++ b/runwayml/text_to_image.py
@@ -7,8 +7,8 @@ import requests
 from griptape.artifacts import BaseArtifact, ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterList, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import prepare_media_data_uri
@@ -221,6 +221,16 @@ class RunwayML_TextToImage(ControlNode):
             )
         )
 
+        # Save the generated image into the active project workspace via the standard
+        # ProjectFileParameter so the file lives next to the user's other artifacts
+        # rather than inside the engine's ephemeral static-files directory.
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runwayml_text_to_image.png",
+        )
+        self._output_file.add_parameter()
+
     def _get_image_data_uri(self, image_input) -> str | None:
         """Convert various image input types to a data URI or HTTPS URL accepted by RunwayML.
 
@@ -290,35 +300,16 @@ class RunwayML_TextToImage(ControlNode):
         return validated
 
     def _download_and_store_image(self, image_url: str, task_id: str = None) -> ImageUrlArtifact:
-        """Download image from URL and store via StaticFilesManager."""
+        """Download image from URL and store in the project workspace."""
         try:
             logger.info(f"RunwayML T2I: Downloading image from {image_url}")
             file_content = File(image_url).read()
 
-            # Determine file extension from content type
-            content_type = file_content.mime_type if file_content.mime_type else "image/png"
-            if "jpeg" in content_type or "jpg" in content_type:
-                extension = "jpg"
-            elif "png" in content_type:
-                extension = "png"
-            elif "webp" in content_type:
-                extension = "webp"
-            else:
-                extension = "jpg"  # Default fallback
-
-            # Generate filename using task ID if provided, otherwise use timestamp
-            if task_id:
-                filename = f"runwayml_generated_image_{task_id}.{extension}"
-            else:
-                timestamp = int(time.time() * 1000)  # milliseconds for uniqueness
-                filename = f"runwayml_generated_image_{timestamp}.{extension}"
-
-            # Save via StaticFilesManager
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-            )
-
-            return ImageUrlArtifact(value=static_url, name="runwayml_generated_image")
+            logger.info("RunwayML T2I: Writing image bytes to project workspace...")
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(file_content.content)
+            logger.info(f"RunwayML T2I: ✅ Image saved as {saved.name} at {saved.location}")
+            return ImageUrlArtifact(value=saved.location, name=saved.name)
 
         except FileLoadError as e:
             logger.error(f"RunwayML T2I: Failed to download and store image: {e}")

--- a/runwayml/video_to_video.py
+++ b/runwayml/video_to_video.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 import subprocess
 import tempfile
@@ -505,11 +506,17 @@ class RunwayML_VideoToVideo(ControlNode):
                             return ErrorArtifact(err_msg)
 
                     elif status == "FAILED":
+                        failure_reason = (
+                            task_status.get("error") or task_status.get("failure") or task_status.get("failureCode")
+                        )
                         error_msg = f"RunwayML V2V generation failed (Task ID: {task_id})."
-                        error_detail = task_status.get("error")
-                        if error_detail:
-                            error_msg += f" Reason: {error_detail}"
-                        logger.error(error_msg)
+                        if failure_reason:
+                            error_msg += f" Reason: {failure_reason}"
+                        logger.error(
+                            "%s Full task status: %s",
+                            error_msg,
+                            json.dumps(task_status, default=str),
+                        )
                         self.publish_update_to_parameter("video_output", ErrorArtifact(error_msg))
                         self.publish_update_to_parameter("seed", actual_seed)
                         return ErrorArtifact(error_msg)

--- a/runwayml/video_to_video.py
+++ b/runwayml/video_to_video.py
@@ -12,9 +12,9 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
     PublicArtifactUrlParameter,
 )
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 from media import prepare_media_data_uri
@@ -172,6 +172,16 @@ class RunwayML_VideoToVideo(ControlNode):
                 ui_options={"placeholder_text": ""},
             )
         )
+
+        # Save the generated video into the active project workspace via the standard
+        # ProjectFileParameter so the file lives next to the user's other artifacts
+        # rather than inside the engine's ephemeral static-files directory.
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runwayml_video_to_video.mp4",
+        )
+        self._output_file.add_parameter()
 
     def _transcode_video_file(self, video_file_path: str) -> str | None:
         """
@@ -371,29 +381,11 @@ class RunwayML_VideoToVideo(ControlNode):
                 logger.info(f"RunwayML V2V: Downloading video from {video_url}")
                 file_content = File(video_url).read()
 
-                content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-                if "quicktime" in content_type or content_type.endswith("/mov"):
-                    extension = "mov"
-                elif "webm" in content_type:
-                    extension = "webm"
-                elif "ogg" in content_type:
-                    extension = "ogv"
-                elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                    extension = "mp4"
-                else:
-                    extension = "mp4"
-
-                if task_id:
-                    filename = f"runwayml_video_to_video_{task_id}.{extension}"
-                else:
-                    filename = f"runwayml_video_to_video_{int(time.time() * 1000)}.{extension}"
-
-                logger.info(f"RunwayML V2V: Saving video bytes to static storage as {filename}...")
-                static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                    file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-                )
-                logger.info(f"RunwayML V2V: ✅ Video saved. URL: {static_url}")
-                return VideoUrlArtifact(url=static_url, name="runwayml_video_to_video")
+                logger.info("RunwayML V2V: Writing video bytes to project workspace...")
+                dest = self._output_file.build_file()
+                saved = dest.write_bytes(file_content.content)
+                logger.info(f"RunwayML V2V: ✅ Video saved as {saved.name} at {saved.location}")
+                return VideoUrlArtifact(url=saved.location, name=saved.name)
             except FileLoadError as e:
                 logger.error(f"RunwayML V2V: Failed to download and store video: {e}")
                 return VideoUrlArtifact(url=video_url, name="runwayml_video_to_video")

--- a/runwayml/video_to_video.py
+++ b/runwayml/video_to_video.py
@@ -8,11 +8,15 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
-from media import coerce_media_url_or_data_uri, prepare_media_data_uri
+from media import prepare_media_data_uri
 
 SERVICE = "RunwayML"
 API_KEY_ENV_VAR = "RUNWAYML_API_SECRET"
@@ -47,20 +51,19 @@ class RunwayML_VideoToVideo(ControlNode):
         )
 
         # Individual parameters
-        # Video Parameter
-        self.add_parameter(
-            Parameter(
+        # Video Parameter. Wrapped with PublicArtifactUrlParameter so RunwayML
+        # receives a public HTTPS URL it can fetch directly, sidestepping the
+        # data-URI body cap.
+        self._public_video = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterVideo(
                 name="video",
-                input_types=["VideoUrlArtifact", "VideoArtifact"],
-                type="VideoUrlArtifact",
-                tooltip="The video to process",
-                ui_options={
-                    "clickable_file_browser": True,
-                    "expander": True,
-                    "display_name": "Video or Path to Video",
-                },
-            )
+                tooltip="The video to process.",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ),
+            disclaimer_message="RunwayML uses this URL to fetch the video for video-to-video generation.",
         )
+        self._public_video.add_input_parameters()
         # Prompt Parameter
         self.add_parameter(
             Parameter(
@@ -248,22 +251,22 @@ class RunwayML_VideoToVideo(ControlNode):
         return f"data:{content_type};base64,{base64_data}"
 
     def _get_video_data_uri(self, param_name: str) -> str | None:
-        """Resolve a video input to a value the /v1/video_to_video endpoint accepts.
+        """Resolve the ``video`` input to a public HTTPS URL via Griptape Cloud upload.
 
-        ``https://`` URLs, ``runway://`` URIs, and ``data:video/...`` URIs pass through
-        unchanged. Anything else (local paths, ``{inputs}/...`` macro paths,
-        ``http://`` URLs, ``file://`` URIs) is read via ``File``, optionally transcoded
-        with ffmpeg, and returned as a ``data:video/mp4;base64,...`` URI so RunwayML
-        receives a known-good format.
+        Public URLs and ``data:video/...`` URIs pass through unchanged; macro paths
+        and local files are uploaded to Griptape Cloud. Returns ``None`` when the
+        parameter is unset.
+
+        Note: this skips the local ``ffmpeg`` transcode step the data-URI path used
+        to perform. RunwayML's API accepts a wider range of formats from a URL than
+        from an inline data URI, so transcoding before upload is no longer necessary
+        in the common case.
         """
-        media_url = coerce_media_url_or_data_uri(self.get_parameter_value(param_name), kind="video")
-        if not media_url:
+        if param_name != "video":
             return None
-
-        if media_url.startswith(("data:video/", "https://", "runway://")):
-            return media_url
-
-        return self._read_to_data_uri(media_url)
+        if not self.get_parameter_value(param_name):
+            return None
+        return self._public_video.get_public_url_for_parameter()
 
     def _get_image_data_uri(self, param_name: str) -> str | None:
         """Resolve a reference-image input to a data URI in a RunwayML-supported format.
@@ -306,13 +309,8 @@ class RunwayML_VideoToVideo(ControlNode):
             )
 
         # Check required video input
-        try:
-            video_data = self._get_video_data_uri("video")
-        except ValueError as e:
-            errors.append(e)
-        else:
-            if not video_data:
-                errors.append(ValueError("Video input ('video') is required and must be a valid URL or data URI."))
+        if not self.get_parameter_value("video"):
+            errors.append(ValueError("Video input ('video') is required."))
 
         # Check prompt
         prompt_val = self.get_parameter_value("prompt")
@@ -363,14 +361,8 @@ class RunwayML_VideoToVideo(ControlNode):
         # Update last used seed for next run
         RunwayML_VideoToVideo._last_used_seed = actual_seed
 
-        # Get video data
-        video_uri = self._get_video_data_uri("video")
-        if not video_uri:
-            error_msg = "Failed to process video input."
-            self.publish_update_to_parameter("video_output", ErrorArtifact(error_msg))
-            raise ValueError(error_msg)
-
-        # Get reference image if provided
+        # Get reference image if provided. This stays inline (data URI) because the
+        # endpoint requires a content-type check that's done on the resolved bytes.
         reference_image_uri = self._get_image_data_uri("reference_image")
 
         def _download_and_store_video(video_url: str, task_id: str | None = None) -> VideoUrlArtifact:
@@ -408,6 +400,9 @@ class RunwayML_VideoToVideo(ControlNode):
         def generate_video_async() -> VideoUrlArtifact | ErrorArtifact:
             try:
                 api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+
+                # Resolve to a public HTTPS URL (uploads to Griptape Cloud if needed).
+                video_uri = self._public_video.get_public_url_for_parameter()
 
                 # Build the payload according to the API format
                 task_payload = {
@@ -542,5 +537,8 @@ class RunwayML_VideoToVideo(ControlNode):
                     "seed", actual_seed if "actual_seed" in locals() else RunwayML_VideoToVideo._last_used_seed
                 )
                 return ErrorArtifact(error_message)
+            finally:
+                # Clean up any artifact uploaded to Griptape Cloud during this run.
+                self._public_video.delete_uploaded_artifact()
 
         yield generate_video_async

--- a/runwayml/video_upscale.py
+++ b/runwayml/video_upscale.py
@@ -5,11 +5,14 @@ import requests
 from griptape.artifacts import ErrorArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
-from media import prepare_media_data_uri
 
 
 # Reuse the VideoUrlArtifact defined alongside ImageUrlArtifact in existing node
@@ -38,24 +41,21 @@ class RunwayML_VideoUpscale(ControlNode):
         self.metadata["author"] = "Griptape"
         self.metadata["dependencies"] = {"pip_dependencies": ["requests"]}
 
-        # Input Parameters
-        self.add_parameter(
-            Parameter(
+        # Input video. Wrapped with PublicArtifactUrlParameter so RunwayML receives a
+        # public HTTPS URL it can fetch directly, sidestepping the data-URI body cap.
+        self._public_video = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterVideo(
                 name="video",
-                input_types=["VideoUrlArtifact", "VideoArtifact"],
-                type="VideoUrlArtifact",
                 tooltip=(
-                    "Input video (HTTPS URL or data URI). Allowed content-types: video/mp4, video/webm, "
-                    "video/quicktime, video/mov, video/ogg, video/h264. Max 16MB; max duration 40s."
+                    "Input video. Allowed content-types: video/mp4, video/webm, video/quicktime, "
+                    "video/mov, video/ogg, video/h264. Max 16MB; max duration 40s."
                 ),
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "clickable_file_browser": True,
-                    "expander": True,
-                    "display_name": "Video or Path to Video",
-                },
-            )
+            ),
+            disclaimer_message="RunwayML uses this URL to fetch the video for upscaling.",
         )
+        self._public_video.add_input_parameters()
 
         self.add_parameter(
             Parameter(
@@ -97,17 +97,14 @@ class RunwayML_VideoUpscale(ControlNode):
 
     # --- Helpers ---
     def _get_video_uri(self) -> str | None:
-        """Resolve the ``video`` input to a value the /v1/video_upscale endpoint accepts.
+        """Resolve the ``video`` input to a public HTTPS URL via Griptape Cloud upload.
 
-        ``https://`` URLs and ``data:video/...`` URIs pass through; macro paths,
-        local files, and ``http://`` URLs are read via ``File`` and returned as
-        ``data:video/mp4;base64,...`` URIs.
+        Public URLs pass through unchanged; macro paths and local files are uploaded.
+        Returns ``None`` when the parameter is unset.
         """
-        return prepare_media_data_uri(
-            self.get_parameter_value("video"),
-            kind="video",
-            node_name="RunwayML VideoUpscale",
-        )
+        if not self.get_parameter_value("video"):
+            return None
+        return self._public_video.get_public_url_for_parameter()
 
     def _download_and_store_video(self, video_url: str, task_id: str | None = None) -> VideoUrlArtifact:
         try:
@@ -201,9 +198,8 @@ class RunwayML_VideoUpscale(ControlNode):
                 )
             )
 
-        video_uri = self._get_video_uri()
-        if not video_uri or not isinstance(video_uri, str) or not video_uri.strip():
-            errors.append(ValueError("Video input ('video') is required and must be a URL or data URI."))
+        if not self.get_parameter_value("video"):
+            errors.append(ValueError("Video input ('video') is required."))
 
         return errors if errors else None
 
@@ -219,11 +215,13 @@ class RunwayML_VideoUpscale(ControlNode):
         self._log_storage_env_hints()
 
         model_name = str(self.get_parameter_value("model") or DEFAULT_MODEL)
-        video_uri = self._get_video_uri()
 
         def upscale_async() -> VideoUrlArtifact | ErrorArtifact:
             try:
                 api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+
+                # Resolve to a public HTTPS URL (uploads to Griptape Cloud if needed).
+                video_uri = self._public_video.get_public_url_for_parameter()
 
                 payload = {"model": model_name, "videoUri": video_uri}
                 logger.info(f"RunwayML VideoUpscale: Creating task with payload keys: {list(payload.keys())}")
@@ -317,5 +315,8 @@ class RunwayML_VideoUpscale(ControlNode):
                 logger.exception(error_message)
                 self.publish_update_to_parameter("video_output", ErrorArtifact(error_message))
                 return ErrorArtifact(error_message)
+            finally:
+                # Clean up any artifact uploaded to Griptape Cloud during this run.
+                self._public_video.delete_uploaded_artifact()
 
         yield upscale_async

--- a/runwayml/video_upscale.py
+++ b/runwayml/video_upscale.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 
@@ -290,10 +291,17 @@ class RunwayML_VideoUpscale(ControlNode):
                             return ErrorArtifact(err_msg)
 
                     if status == "FAILED":
+                        failure_reason = (
+                            status_resp.get("error") or status_resp.get("failure") or status_resp.get("failureCode")
+                        )
                         error_msg = f"RunwayML VideoUpscale failed (Task ID: {task_id})."
-                        if getattr(status_resp, "error", None):
-                            error_msg += f" Reason: {getattr(status_resp, 'error', None)}"
-                        logger.error(error_msg)
+                        if failure_reason:
+                            error_msg += f" Reason: {failure_reason}"
+                        logger.error(
+                            "%s Full task status: %s",
+                            error_msg,
+                            json.dumps(status_resp, default=str),
+                        )
                         self.publish_update_to_parameter("video_output", ErrorArtifact(error_msg))
                         return ErrorArtifact(error_msg)
 

--- a/runwayml/video_upscale.py
+++ b/runwayml/video_upscale.py
@@ -1,5 +1,4 @@
 import json
-import os
 import time
 
 import requests
@@ -9,9 +8,9 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
     PublicArtifactUrlParameter,
 )
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 
@@ -96,6 +95,16 @@ class RunwayML_VideoUpscale(ControlNode):
             )
         )
 
+        # Save the upscaled video into the active project workspace via the standard
+        # ProjectFileParameter so the file lives next to the user's other artifacts
+        # rather than inside the engine's ephemeral static-files directory.
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runwayml_video_upscale.mp4",
+        )
+        self._output_file.add_parameter()
+
     # --- Helpers ---
     def _get_video_uri(self) -> str | None:
         """Resolve the ``video`` input to a public HTTPS URL via Griptape Cloud upload.
@@ -112,81 +121,15 @@ class RunwayML_VideoUpscale(ControlNode):
             logger.info(f"RunwayML VideoUpscale: Downloading video from {video_url}")
             file_content = File(video_url).read()
 
-            content_type = file_content.mime_type.lower() if file_content.mime_type else "video/mp4"
-            # Basic mapping for common content-types
-            if "quicktime" in content_type or content_type.endswith("/mov"):
-                extension = "mov"
-            elif "webm" in content_type:
-                extension = "webm"
-            elif "ogg" in content_type:
-                extension = "ogv"
-            elif "h264" in content_type or "mp4" in content_type or "mpeg4" in content_type:
-                extension = "mp4"
-            else:
-                extension = "mp4"
-
-            if task_id:
-                filename = f"runwayml_upscaled_video_{task_id}.{extension}"
-            else:
-                filename = f"runwayml_upscaled_video_{int(time.time() * 1000)}.{extension}"
-
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                file_content.content, filename, ExistingFilePolicy.CREATE_NEW
-            )
-            return VideoUrlArtifact(url=static_url, name="runwayml_upscaled_video")
+            logger.info("RunwayML VideoUpscale: Writing video bytes to project workspace...")
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(file_content.content)
+            logger.info(f"RunwayML VideoUpscale: ✅ Video saved as {saved.name} at {saved.location}")
+            return VideoUrlArtifact(url=saved.location, name=saved.name)
         except FileLoadError as e:
             logger.error(f"RunwayML VideoUpscale: Failed to download and store video: {e}")
             # Fallback to original URL if we can't save
             return VideoUrlArtifact(url=video_url, name="runwayml_video")
-
-    def _log_storage_env_hints(self) -> None:
-        try:
-            sm = GriptapeNodes.StaticFilesManager()
-            logger.info("RunwayML VideoUpscale: StaticFilesManager instance: %s", sm.__class__.__name__)
-            # Attempt to log likely backend attribute names if present (without secrets)
-            backend_attr_names = [
-                n for n in dir(sm) if any(k in n.lower() for k in ["backend", "storage", "bucket", "client"])
-            ]
-            logger.info("RunwayML VideoUpscale: StaticFilesManager attrs (subset): %s", backend_attr_names)
-
-            # Environment hints (keys only + masked preview)
-            prefixes = [
-                "GT_",
-                "GRIPTAPE_",
-                "STATIC_",
-                "STORAGE_",
-                "AWS_",
-                "AZURE_",
-                "GCP_",
-                "GOOGLE_",
-                "GCLOUD_",
-                "S3_",
-                "R2_",
-                "DO_SPACES_",
-                "SUPABASE_",
-                "MINIO_",
-                "BUCKET_",
-                "BACKBLAZE_",
-                "B2_",
-                "CLOUDFLARE_",
-            ]
-
-            def _mask(val: str) -> str:
-                s = str(val)
-                if len(s) <= 8:
-                    return "***"
-                return s[:3] + "***" + s[-2:]
-
-            matched = []
-            for k, v in os.environ.items():
-                if any(k.startswith(p) for p in prefixes):
-                    matched.append((k, _mask(v)))
-            if matched:
-                logger.info("RunwayML VideoUpscale: Detected env keys: %s", [k for k, _ in matched])
-            else:
-                logger.info("RunwayML VideoUpscale: No storage-related env keys detected")
-        except Exception as e:
-            logger.warning(f"RunwayML VideoUpscale: Failed to log storage env hints: {e}")
 
     # --- Execution ---
     def validate_node(self) -> list[Exception] | None:
@@ -211,9 +154,6 @@ class RunwayML_VideoUpscale(ControlNode):
             logger.error(f"RunwayML VideoUpscale validation failed: {error_message}")
             self.publish_update_to_parameter("video_output", ErrorArtifact(error_message))
             raise ValueError(f"Validation failed: {error_message}")
-
-        # Log storage/backend hints once per run
-        self._log_storage_env_hints()
 
         model_name = str(self.get_parameter_value("model") or DEFAULT_MODEL)
 

--- a/tests/test_act_two.py
+++ b/tests/test_act_two.py
@@ -1,22 +1,46 @@
 """Node-level checks for ``RunwayML_ActTwo``.
 
 Coercion of arbitrary input shapes is exercised in
-``tests/unit/media/test_coercion.py``; this module only covers the wiring
-between Act Two's parameters and the shared helper.
+``tests/unit/media/test_coercion.py``; this module covers the wiring between
+Act Two's parameters, ``PublicArtifactUrlParameter`` uploads, and the API
+payload.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from act_two import RunwayML_ActTwo, VideoUrlArtifact
-from griptape.artifacts import ImageUrlArtifact
+
+
+@pytest.fixture(autouse=True)
+def _stub_public_artifact_dependencies() -> Iterator[None]:
+    """Patch out Griptape Cloud calls so ``PublicArtifactUrlParameter`` constructs offline.
+
+    The component normally requires ``GT_CLOUD_API_KEY`` and a live bucket lookup at
+    construction time; we don't need either to exercise node-level wiring.
+    """
+    with (
+        patch(
+            "griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter.PublicArtifactUrlParameter._get_secret_value",
+            return_value="fake-key",
+        ),
+        patch(
+            "griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter.PublicArtifactUrlParameter._get_bucket_id",
+            return_value="fake-bucket",
+        ),
+        patch(
+            "griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter.GriptapeCloudStorageDriver"
+        ),
+    ):
+        yield
 
 
 @pytest.fixture
-def node() -> RunwayML_ActTwo:
+def node():
+    from act_two import RunwayML_ActTwo
+
     return RunwayML_ActTwo(name="test")
 
 
@@ -27,38 +51,40 @@ def _stub_secret() -> Iterator[None]:
         yield
 
 
-def _set_minimal_required(node: RunwayML_ActTwo) -> None:
+def _set_minimal_required(node) -> None:
     node.set_parameter_value("character_type", "image")
     node.set_parameter_value("ratio", "1280:720")
     node.set_parameter_value("expression_intensity", 3)
     node.set_parameter_value("model", "act_two")
 
 
-def test_https_image_and_video_validate_without_loading(node: RunwayML_ActTwo) -> None:
+def test_public_url_wrappers_registered_for_each_media_input(node) -> None:
+    """Each media input must be wrapped so RunwayML receives an HTTPS URL, not a data URI."""
+    assert node._public_character_image is not None
+    assert node._public_character_video is not None
+    assert node._public_reference_video is not None
+    # The wrapped ``Parameter`` instances were registered on the node, with their original names.
+    assert node.get_parameter_by_name("character_image") is node._public_character_image._parameter
+    assert node.get_parameter_by_name("character_video") is node._public_character_video._parameter
+    assert node.get_parameter_by_name("reference_video") is node._public_reference_video._parameter
+
+
+def test_validation_passes_when_required_inputs_are_present(node) -> None:
+    """``validate_node`` only checks presence; it must not trigger uploads."""
     _set_minimal_required(node)
-    node.set_parameter_value("character_image", "https://example.com/i.png")
-    node.set_parameter_value("reference_video", "https://example.com/v.mp4")
+    node.set_parameter_value("character_image", "{inputs}/image_196.png")
+    node.set_parameter_value("reference_video", "{inputs}/clip.mp4")
 
-    assert node.validate_node() is None
-
-
-def test_url_artifact_with_macro_path_resolves_via_file(node: RunwayML_ActTwo) -> None:
-    """Regression: ``LoadImage``/``LoadVideo`` outputs use ``{inputs}/...`` macro paths."""
-    _set_minimal_required(node)
-    node.set_parameter_value("character_image", ImageUrlArtifact("{inputs}/image_196.png"))
-    node.set_parameter_value("reference_video", VideoUrlArtifact("{inputs}/clip.mp4"))
-
-    with patch("media.coercion.File") as MockFile:
-        MockFile.return_value.read_data_uri.side_effect = [
-            "data:image/png;base64,IMG",
-            "data:video/mp4;base64,VID",
-        ]
+    with (
+        patch.object(node._public_character_image, "get_public_url_for_parameter") as mock_image,
+        patch.object(node._public_reference_video, "get_public_url_for_parameter") as mock_video,
+    ):
         assert node.validate_node() is None
-        assert MockFile.call_args_list[0].args[0] == "{inputs}/image_196.png"
-        assert MockFile.call_args_list[1].args[0] == "{inputs}/clip.mp4"
+        mock_image.assert_not_called()
+        mock_video.assert_not_called()
 
 
-def test_missing_character_image_yields_required_error(node: RunwayML_ActTwo) -> None:
+def test_missing_character_image_yields_required_error(node) -> None:
     _set_minimal_required(node)
     node.set_parameter_value("character_image", None)
     node.set_parameter_value("reference_video", "https://example.com/v.mp4")
@@ -68,7 +94,7 @@ def test_missing_character_image_yields_required_error(node: RunwayML_ActTwo) ->
     assert any("Character image is required" in str(e) for e in errors)
 
 
-def test_missing_reference_video_yields_required_error(node: RunwayML_ActTwo) -> None:
+def test_missing_reference_video_yields_required_error(node) -> None:
     _set_minimal_required(node)
     node.set_parameter_value("character_image", "https://example.com/i.png")
     node.set_parameter_value("reference_video", None)
@@ -76,3 +102,77 @@ def test_missing_reference_video_yields_required_error(node: RunwayML_ActTwo) ->
     errors = node.validate_node()
     assert errors is not None
     assert any("Reference video" in str(e) for e in errors)
+
+
+def test_process_uploads_image_and_video_then_cleans_up(node) -> None:
+    """Regression: with a macro-path image and video, both wrappers upload, the API gets
+    HTTPS URLs (no data URIs), and uploaded artifacts are deleted regardless of API outcome.
+    """
+    _set_minimal_required(node)
+    node.set_parameter_value("character_image", "{inputs}/image_196.png")
+    node.set_parameter_value("reference_video", "{inputs}/clip.mp4")
+
+    image_url = "https://cloud.griptape.ai/storage/abc/img.png"
+    video_url = "https://cloud.griptape.ai/storage/abc/clip.mp4"
+
+    with (
+        patch.object(node._public_character_image, "get_public_url_for_parameter", return_value=image_url) as up_image,
+        patch.object(node._public_reference_video, "get_public_url_for_parameter", return_value=video_url) as up_video,
+        patch.object(node._public_character_image, "delete_uploaded_artifact") as cleanup_image,
+        patch.object(node._public_character_video, "delete_uploaded_artifact") as cleanup_char_video,
+        patch.object(node._public_reference_video, "delete_uploaded_artifact") as cleanup_ref_video,
+        patch("act_two.requests") as mock_requests,
+    ):
+        post_response = MagicMock(status_code=200)
+        post_response.json.return_value = {"id": "task-1"}
+        get_response = MagicMock(status_code=200)
+        get_response.json.return_value = {"status": "SUCCEEDED", "output": [{"url": "https://out/v.mp4"}]}
+        mock_requests.post.return_value = post_response
+        mock_requests.get.return_value = get_response
+
+        # Run the yielded async work synchronously.
+        result_gen = node.process()
+        async_fn = next(result_gen)
+        with patch("act_two.time.sleep"):
+            with patch.object(node, "_download_and_store_video", create=True):
+                # Defensive: if the node tries to download, just no-op.
+                async_fn()
+
+    up_image.assert_called_once()
+    up_video.assert_called_once()
+
+    sent_payload = mock_requests.post.call_args.kwargs["json"]
+    assert sent_payload["character"]["uri"] == image_url
+    assert sent_payload["reference"]["uri"] == video_url
+    assert not sent_payload["character"]["uri"].startswith("data:")
+    assert not sent_payload["reference"]["uri"].startswith("data:")
+
+    cleanup_image.assert_called_once()
+    cleanup_char_video.assert_called_once()
+    cleanup_ref_video.assert_called_once()
+
+
+def test_process_cleans_up_when_api_call_fails(node) -> None:
+    _set_minimal_required(node)
+    node.set_parameter_value("character_image", "{inputs}/image_196.png")
+    node.set_parameter_value("reference_video", "{inputs}/clip.mp4")
+
+    with (
+        patch.object(node._public_character_image, "get_public_url_for_parameter", return_value="https://x/i.png"),
+        patch.object(node._public_reference_video, "get_public_url_for_parameter", return_value="https://x/v.mp4"),
+        patch.object(node._public_character_image, "delete_uploaded_artifact") as cleanup_image,
+        patch.object(node._public_character_video, "delete_uploaded_artifact") as cleanup_char_video,
+        patch.object(node._public_reference_video, "delete_uploaded_artifact") as cleanup_ref_video,
+        patch("act_two.requests") as mock_requests,
+    ):
+        post_response = MagicMock(status_code=500, text="server boom")
+        mock_requests.post.return_value = post_response
+
+        result_gen = node.process()
+        async_fn = next(result_gen)
+        with patch("act_two.time.sleep"):
+            async_fn()
+
+    cleanup_image.assert_called_once()
+    cleanup_char_video.assert_called_once()
+    cleanup_ref_video.assert_called_once()

--- a/tests/test_video_to_video.py
+++ b/tests/test_video_to_video.py
@@ -1,23 +1,41 @@
 """Node-level checks for ``RunwayML_VideoToVideo``.
 
-The general coercion behaviour is covered in
-``tests/unit/media/test_coercion.py``; this module only covers V2V-specific
-wiring: format validation on reference images, and the transcoding-aware video
-path.
+Coercion of arbitrary input shapes is exercised in
+``tests/unit/media/test_coercion.py``; this module covers V2V-specific
+wiring: ``PublicArtifactUrlParameter`` upload of the input video, and
+reference-image format validation.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from griptape.artifacts import ImageUrlArtifact
-from video_to_video import RunwayML_VideoToVideo, VideoUrlArtifact
+
+
+@pytest.fixture(autouse=True)
+def _stub_public_artifact_dependencies() -> Iterator[None]:
+    with (
+        patch(
+            "griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter.PublicArtifactUrlParameter._get_secret_value",
+            return_value="fake-key",
+        ),
+        patch(
+            "griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter.PublicArtifactUrlParameter._get_bucket_id",
+            return_value="fake-bucket",
+        ),
+        patch(
+            "griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter.GriptapeCloudStorageDriver"
+        ),
+    ):
+        yield
 
 
 @pytest.fixture
-def node() -> RunwayML_VideoToVideo:
+def node():
+    from video_to_video import RunwayML_VideoToVideo
+
     return RunwayML_VideoToVideo(name="test")
 
 
@@ -28,106 +46,26 @@ def _stub_secret() -> Iterator[None]:
         yield
 
 
-def _set_minimal_required(node: RunwayML_VideoToVideo) -> None:
+def _set_minimal_required(node) -> None:
     node.set_parameter_value("prompt", "hello")
     node.set_parameter_value("model", "gen4_aleph")
 
 
-# ---------------------------------------------------------------------------
-# Video pass-through and reads
-# ---------------------------------------------------------------------------
+def test_video_input_is_wrapped_with_public_artifact_url_parameter(node) -> None:
+    assert node._public_video is not None
+    assert node.get_parameter_by_name("video") is node._public_video._parameter
 
 
-@pytest.mark.parametrize(
-    "video_uri",
-    [
-        "https://example.com/v.mp4",
-        "runway://dataset/abc",
-        "data:video/mp4;base64,AAAA",
-    ],
-)
-def test_pass_through_video_uris_skip_transcoding(node: RunwayML_VideoToVideo, video_uri: str) -> None:
-    """Schemes the API accepts directly must not be downloaded or transcoded."""
+def test_validation_passes_when_required_inputs_are_present(node) -> None:
     _set_minimal_required(node)
-    node.set_parameter_value("video", video_uri)
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
 
-    with (
-        patch.object(RunwayML_VideoToVideo, "_read_to_data_uri") as mock_read,
-        patch.object(RunwayML_VideoToVideo, "_transcode_video_file") as mock_transcode,
-    ):
-        assert node._get_video_data_uri("video") == video_uri
-        mock_read.assert_not_called()
-        mock_transcode.assert_not_called()
+    with patch.object(node._public_video, "get_public_url_for_parameter") as mock_upload:
+        assert node.validate_node() is None
+        mock_upload.assert_not_called()
 
 
-def test_local_video_path_is_read_and_transcoded(node: RunwayML_VideoToVideo) -> None:
-    _set_minimal_required(node)
-    node.set_parameter_value("video", "/Volumes/inputs/v.mp4")
-
-    with patch.object(
-        RunwayML_VideoToVideo,
-        "_read_to_data_uri",
-        return_value="data:video/mp4;base64,READ",
-    ) as mock_read:
-        assert node._get_video_data_uri("video") == "data:video/mp4;base64,READ"
-        mock_read.assert_called_once_with("/Volumes/inputs/v.mp4")
-
-
-def test_macro_path_video_url_artifact_is_read(node: RunwayML_VideoToVideo) -> None:
-    """Regression: ``LoadVideo`` outputs use ``{inputs}/...`` macro paths."""
-    _set_minimal_required(node)
-    node.set_parameter_value("video", VideoUrlArtifact("{inputs}/clip.mp4"))
-
-    with patch.object(
-        RunwayML_VideoToVideo,
-        "_read_to_data_uri",
-        return_value="data:video/mp4;base64,READ",
-    ) as mock_read:
-        assert node._get_video_data_uri("video") == "data:video/mp4;base64,READ"
-        mock_read.assert_called_once_with("{inputs}/clip.mp4")
-
-
-# ---------------------------------------------------------------------------
-# Reference image format validation
-# ---------------------------------------------------------------------------
-
-
-def test_supported_image_data_uri_passes(node: RunwayML_VideoToVideo) -> None:
-    node.set_parameter_value("reference_image", "data:image/jpeg;base64,AAAA")
-    assert node._get_image_data_uri("reference_image") == "data:image/jpeg;base64,AAAA"
-
-
-def test_unsupported_image_data_uri_raises(node: RunwayML_VideoToVideo) -> None:
-    node.set_parameter_value("reference_image", "data:image/gif;base64,AAAA")
-    with pytest.raises(ValueError, match="Unsupported reference image format"):
-        node._get_image_data_uri("reference_image")
-
-
-def test_https_image_url_is_downloaded_for_format_check(node: RunwayML_VideoToVideo) -> None:
-    """Force-fetch HTTPS so we can inspect the content type before sending to RunwayML."""
-    node.set_parameter_value("reference_image", ImageUrlArtifact("https://example.com/i.png"))
-
-    with patch("media.coercion.File") as MockFile:
-        MockFile.return_value.read_data_uri.return_value = "data:image/png;base64,READ"
-        result = node._get_image_data_uri("reference_image")
-
-    assert result == "data:image/png;base64,READ"
-    MockFile.assert_called_with("https://example.com/i.png")
-
-
-# ---------------------------------------------------------------------------
-# validate_node
-# ---------------------------------------------------------------------------
-
-
-def test_valid_https_video_validates(node: RunwayML_VideoToVideo) -> None:
-    _set_minimal_required(node)
-    node.set_parameter_value("video", "https://example.com/v.mp4")
-
-    assert node.validate_node() is None
-
-
-def test_missing_video_yields_required_error(node: RunwayML_VideoToVideo) -> None:
+def test_missing_video_yields_required_error(node) -> None:
     _set_minimal_required(node)
     node.set_parameter_value("video", None)
 
@@ -136,14 +74,78 @@ def test_missing_video_yields_required_error(node: RunwayML_VideoToVideo) -> Non
     assert any("required" in str(e) for e in errors)
 
 
-def test_local_video_path_validates_when_read_succeeds(node: RunwayML_VideoToVideo) -> None:
-    """Regression for #28: macro paths and absolute paths must validate, not be rejected."""
+def test_missing_prompt_yields_required_error(node) -> None:
+    _set_minimal_required(node)
+    node.set_parameter_value("video", "https://example.com/v.mp4")
+    node.set_parameter_value("prompt", "")
+
+    errors = node.validate_node()
+    assert errors is not None
+    assert any("prompt" in str(e).lower() for e in errors)
+
+
+def test_process_uploads_video_then_cleans_up(node) -> None:
+    """Macro paths get uploaded to Griptape Cloud; the API receives an HTTPS URL."""
     _set_minimal_required(node)
     node.set_parameter_value("video", "{inputs}/clip.mp4")
 
-    with patch.object(
-        RunwayML_VideoToVideo,
-        "_read_to_data_uri",
-        return_value="data:video/mp4;base64,READ",
+    public_url = "https://cloud.griptape.ai/storage/abc/clip.mp4"
+
+    with (
+        patch.object(node._public_video, "get_public_url_for_parameter", return_value=public_url) as upload,
+        patch.object(node._public_video, "delete_uploaded_artifact") as cleanup,
+        patch("video_to_video.requests") as mock_requests,
+        patch("video_to_video.time.sleep"),
     ):
-        assert node.validate_node() is None
+        post = MagicMock(status_code=200)
+        post.json.return_value = {"id": "task-1"}
+        get_resp = MagicMock(status_code=200)
+        get_resp.json.return_value = {"status": "SUCCEEDED", "output": [{"url": "https://out/v.mp4"}]}
+        mock_requests.post.return_value = post
+        mock_requests.get.return_value = get_resp
+
+        result_gen = node.process()
+        async_fn = next(result_gen)
+        async_fn()
+
+    upload.assert_called_once()
+    payload = mock_requests.post.call_args.kwargs["json"]
+    assert payload["videoUri"] == public_url
+    assert not payload["videoUri"].startswith("data:")
+    cleanup.assert_called_once()
+
+
+def test_process_cleans_up_when_api_call_fails(node) -> None:
+    _set_minimal_required(node)
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+
+    with (
+        patch.object(node._public_video, "get_public_url_for_parameter", return_value="https://x/v.mp4"),
+        patch.object(node._public_video, "delete_uploaded_artifact") as cleanup,
+        patch("video_to_video.requests") as mock_requests,
+        patch("video_to_video.time.sleep"),
+    ):
+        post = MagicMock(status_code=500, text="server boom")
+        mock_requests.post.return_value = post
+
+        result_gen = node.process()
+        async_fn = next(result_gen)
+        async_fn()
+
+    cleanup.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Reference image format validation (kept inline; not migrated to PublicArtifactUrlParameter)
+# ---------------------------------------------------------------------------
+
+
+def test_supported_reference_image_data_uri_passes(node) -> None:
+    node.set_parameter_value("reference_image", "data:image/jpeg;base64,AAAA")
+    assert node._get_image_data_uri("reference_image") == "data:image/jpeg;base64,AAAA"
+
+
+def test_unsupported_reference_image_data_uri_raises(node) -> None:
+    node.set_parameter_value("reference_image", "data:image/gif;base64,AAAA")
+    with pytest.raises(ValueError, match="Unsupported reference image format"):
+        node._get_image_data_uri("reference_image")


### PR DESCRIPTION
Closes #30.

Local files and project macro paths (`{inputs}/foo.png`) sent to RunwayML as inline data URIs hit the API's ~5MB request-body cap once base64 inflation is applied, rejecting plenty of inputs that are otherwise reasonable.

Wraps the media inputs in Act Two (`character_image`, `character_video`, `reference_video`), V2V (`video`), I2V (`image`), and Video Upscale (`video`) with `PublicArtifactUrlParameter`. Each affected node now resolves its media input to a Griptape Cloud HTTPS URL inside its async work and calls `delete_uploaded_artifact()` in `finally` so uploads are cleaned up regardless of API outcome. Public URLs the user pasted in pass through unchanged; everything else is uploaded.

V2V `reference_image` stays on `prepare_media_data_uri` because RunwayML enforces a JPEG/PNG/WebP-only check that we have to do on the resolved bytes, and T2I keeps its existing PNG-conversion path because `reference_images` is a `ParameterList` rather than a single parameter.

Depends on griptape-ai/griptape-cloud#1905. Without that fix the presigned URLs come back with `Content-Type: application/octet-stream`, which RunwayML rejects (see griptape-ai/griptape-cloud#1959).